### PR TITLE
Add Azure DevOps pipeline templates

### DIFF
--- a/cicd-examples/azure-devops/azure-pipelines-ephemeral-app-blocking-mode.yml
+++ b/cicd-examples/azure-devops/azure-pipelines-ephemeral-app-blocking-mode.yml
@@ -1,0 +1,242 @@
+# Probely Security Scan - Ephemeral App in Blocking Mode
+# This pipeline builds and scans a containerized application within the CI/CD environment
+# The scan runs in blocking mode, waiting for completion before proceeding
+
+trigger:
+  branches:
+    include:
+    - main
+    - develop
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  # Configure these variables in Azure DevOps Pipeline Variables
+  # TARGET_ID: Your Probely target ID
+  # TARGET_HOSTNAME: Internal hostname (e.g., custom-web-app)
+  # TARGET_URL: Full target URL (e.g., http://custom-web-app:8080)
+
+stages:
+- stage: BuildAndScan
+  displayName: 'Build and Security Scan'
+  jobs:
+  - job: SecurityScan
+    displayName: 'Run Probely Security Scan'
+    steps:
+    
+    # Step 1: Checkout code
+    - checkout: self
+      displayName: 'Checkout Repository'
+    
+    # Step 2: Create custom Docker network
+    - task: Bash@3
+      displayName: 'Create custom Docker network'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker network create custom-network
+    
+    # Step 3: Build and run the Docker app container
+    - task: Bash@3
+      displayName: 'Build and run app container'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Build the Docker image
+          docker build -t test-app .
+          
+          # Run the Docker container with a custom hostname
+          docker run --name test-app \
+            --hostname custom-web-app \
+            --network custom-network \
+            -p 8080:8080 \
+            -d test-app
+    
+    # Step 4: Add container IP to /etc/hosts
+    - task: Bash@3
+      displayName: 'Configure container hostname'
+      inputs:
+        targetType: 'inline'
+        script: |
+          CONTAINER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' test-app)
+          echo "Container IP is $CONTAINER_IP"
+          
+          # Add the custom hostname to the /etc/hosts file
+          echo "$CONTAINER_IP $(TARGET_HOSTNAME) $(TARGET_HOSTNAME)." | sudo tee -a /etc/hosts
+          cat /etc/hosts
+    
+    # Step 5: Wait for the app to start
+    - task: Bash@3
+      displayName: 'Wait for app to start'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Wait until the container is ready
+          for i in {1..10}; do
+            if curl -s $(TARGET_URL) > /dev/null; then
+              echo "App is up!";
+              break;
+            fi
+            echo "Waiting for the app to be ready...";
+            sleep 2;
+          done
+    
+    # Step 6: Test application with curl
+    - task: Bash@3
+      displayName: 'Test application'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Make a request to the web app using the custom hostname
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" $(TARGET_URL))
+          
+          if [ "$RESPONSE" -ne 200 ]; then
+            echo "App test failed with HTTP status $RESPONSE";
+            exit 1;
+          fi
+          
+          curl -s -i $(TARGET_URL)
+          echo "App test passed with HTTP status $RESPONSE";
+    
+    # Step 7: Start Probely Scanning Agent
+    - task: Bash@3
+      displayName: 'Start Probely Scanning Agent'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Using docker agent
+          docker run -d --name probely-agent \
+            --cap-add NET_ADMIN \
+            --network custom-network \
+            -e FARCASTER_AGENT_TOKEN=$(AGENT_TOKEN) \
+            --device /dev/net/tun probely/farcaster-onprem-agent:v2
+      env:
+        AGENT_TOKEN: $(AGENT_TOKEN)
+    
+    # Step 8: Wait for agent to start
+    - task: Bash@3
+      displayName: 'Wait for agent to start'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Wait until the probely-agent is ready
+          for i in {1..10}; do
+            echo "-----------------------------------"
+            AGENT_RUNNING=$(docker logs probely-agent | grep 'Running...' | wc -l)
+            if [ $AGENT_RUNNING == "1" ]; then
+              echo "Agent is running!";
+              echo "------------------------"
+              docker logs probely-agent
+              echo "------------------------"
+              sleep 10
+              break;
+            fi
+            sleep 2;
+          done
+    
+    # Step 9: Install Probely CLI
+    - task: Bash@3
+      displayName: 'Install Probely CLI'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Install Probely CLI
+          pip install probely
+          # Test probely GET TARGETS
+          probely targets get --api-key $(PROBELY_API_KEY)
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+    
+    # Step 10: Start Security Scan
+    - task: Bash@3
+      displayName: 'Start Probely Scan'
+      inputs:
+        targetType: 'inline'
+        script: |
+          for i in {1..20}; do
+            echo "-----------------------------------"
+            SCAN_ID=$(probely targets start-scan $(TARGET_ID) -o IDS_ONLY --api-key $(PROBELY_API_KEY))
+            echo ${SCAN_ID}
+            if [ -f ${SCAN_ID} ]; then
+              echo "Scan didn't start... Retry start-scan"
+            else
+              echo "Scan started with SCAN ID: ${SCAN_ID}";
+              echo "##vso[task.setvariable variable=SCAN_ID]${SCAN_ID}"
+              break;
+            fi
+            sleep 5
+          done
+          if [ -f ${SCAN_ID} ]; then
+            echo "No Scan ID, aborting..."
+            docker stop test-app
+            docker stop probely-agent
+            docker rm test-app
+            docker rm probely-agent
+            docker network rm custom-network
+            exit 1
+          fi
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        TARGET_ID: $(TARGET_ID)
+    
+    # Step 11: Wait for scan to complete
+    - task: Bash@3
+      displayName: 'Wait for scan to complete'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Wait until scan ends
+          while true; do
+            echo "-----------------------------------"
+            SCAN_OUTPUT=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) | tail -1)
+            echo ${SCAN_OUTPUT}
+            echo "-----------------------------------"
+            SCAN_STATUS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].status')
+            if [ $SCAN_STATUS == "started" ] || [ $SCAN_STATUS == "queued" ]; then
+              echo "Scan is running or queued!";
+            else
+              echo "Scan is not running... finishing"
+              break;
+            fi
+            sleep 30;
+          done
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        SCAN_ID: $(SCAN_ID)
+    
+    # Step 12: Check for high vulnerabilities
+    - task: Bash@3
+      displayName: 'Check for high vulnerabilities'
+      inputs:
+        targetType: 'inline'
+        script: |
+          HIGH_VULNS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].highs')
+          echo "HIGH vulnerabilities: ${HIGH_VULNS}"
+          if [ ${HIGH_VULNS} -gt 0 ]; then
+            echo "Scan has High vulnerabilities... aborting"
+            docker stop test-app
+            docker stop probely-agent
+            docker rm test-app
+            docker rm probely-agent
+            docker network rm custom-network
+            exit 1
+          else
+            echo "Scan doesn't have high vulnerabilities"
+          fi
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        SCAN_ID: $(SCAN_ID)
+    
+    # Step 13: Clean up Docker resources
+    - task: Bash@3
+      displayName: 'Clean up Docker resources'
+      condition: always()
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker stop test-app || true
+          docker stop probely-agent || true
+          docker rm test-app || true
+          docker rm probely-agent || true
+          docker network rm custom-network || true

--- a/cicd-examples/azure-devops/azure-pipelines-ephemeral-app-blocking-mode.yml
+++ b/cicd-examples/azure-devops/azure-pipelines-ephemeral-app-blocking-mode.yml
@@ -192,7 +192,7 @@ stages:
             SCAN_OUTPUT=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) | tail -1)
             echo ${SCAN_OUTPUT}
             echo "-----------------------------------"
-            SCAN_STATUS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].status')
+            SCAN_STATUS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.status')
             if [ $SCAN_STATUS == "started" ] || [ $SCAN_STATUS == "queued" ]; then
               echo "Scan is running or queued!";
             else
@@ -211,7 +211,7 @@ stages:
       inputs:
         targetType: 'inline'
         script: |
-          HIGH_VULNS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].highs')
+          HIGH_VULNS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.highs')
           echo "HIGH vulnerabilities: ${HIGH_VULNS}"
           if [ ${HIGH_VULNS} -gt 0 ]; then
             echo "Scan has High vulnerabilities... aborting"

--- a/cicd-examples/azure-devops/azure-pipelines-remote-app-blocking-mode.yml
+++ b/cicd-examples/azure-devops/azure-pipelines-remote-app-blocking-mode.yml
@@ -75,7 +75,7 @@ stages:
             SCAN_OUTPUT=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) | tail -1)
             echo ${SCAN_OUTPUT}
             echo "-----------------------------------"
-            SCAN_STATUS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].status')
+            SCAN_STATUS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.status')
             if [ $SCAN_STATUS == "started" ] || [ $SCAN_STATUS == "queued" ]; then
               echo "Scan is running or queued!";
             else
@@ -95,7 +95,7 @@ stages:
         targetType: 'inline'
         script: |
           # Check for high-risk vulnerabilities
-          HIGH_VULNS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].highs')
+          HIGH_VULNS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.highs')
           echo "HIGH risk vulnerabilities: ${HIGH_VULNS}"
           if [[ "$HIGH_VULNS" -gt 0 ]]; then
             echo "Scan has High risk vulnerabilities... aborting"

--- a/cicd-examples/azure-devops/azure-pipelines-remote-app-blocking-mode.yml
+++ b/cicd-examples/azure-devops/azure-pipelines-remote-app-blocking-mode.yml
@@ -1,0 +1,108 @@
+# Probely Security Scan - Remote App in Blocking Mode
+# This pipeline scans a remote application (already running on your server)
+# The scan runs in blocking mode and will fail the pipeline if high-risk vulnerabilities are found
+
+trigger:
+  branches:
+    include:
+    - main
+    - develop
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  # Configure these variables in Azure DevOps Pipeline Variables
+  # TARGET_ID: Your Probely target ID
+
+stages:
+- stage: SecurityScan
+  displayName: 'Security Scan'
+  jobs:
+  - job: ProbelyScan
+    displayName: 'Run Probely Security Scan'
+    steps:
+    
+    # Step 1: Install Probely CLI
+    - task: Bash@3
+      displayName: 'Install Probely CLI'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Install Probely CLI
+          pip install probely
+          # Test probely GET TARGETS
+          probely targets get --api-key $(PROBELY_API_KEY)
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+    
+    # Step 2: Start Security Scan
+    - task: Bash@3
+      displayName: 'Start Probely Scan'
+      inputs:
+        targetType: 'inline'
+        script: |
+          for i in {1..20}; do
+            echo "-----------------------------------"
+            SCAN_ID=$(probely targets start-scan $(TARGET_ID) -o IDS_ONLY --api-key $(PROBELY_API_KEY))
+            echo ${SCAN_ID}
+            if [ -f ${SCAN_ID} ]; then
+              echo "Scan didn't start... Retry start-scan"
+            else
+              echo "Scan started with SCAN ID: ${SCAN_ID}";
+              echo "##vso[task.setvariable variable=SCAN_ID]${SCAN_ID}"
+              break;
+            fi
+            sleep 5
+          done
+          if [ -f ${SCAN_ID} ]; then
+            echo "No Scan ID, aborting..."
+            exit 1
+          fi
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        TARGET_ID: $(TARGET_ID)
+    
+    # Step 3: Wait for scan to complete
+    - task: Bash@3
+      displayName: 'Wait for scan to complete'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Wait until scan ends
+          while true; do
+            echo "-----------------------------------"
+            SCAN_OUTPUT=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) | tail -1)
+            echo ${SCAN_OUTPUT}
+            echo "-----------------------------------"
+            SCAN_STATUS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].status')
+            if [ $SCAN_STATUS == "started" ] || [ $SCAN_STATUS == "queued" ]; then
+              echo "Scan is running or queued!";
+            else
+              echo "Scan is not running... finishing"
+              break;
+            fi
+            sleep 30;
+          done
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        SCAN_ID: $(SCAN_ID)
+    
+    # Step 4: Check for high-risk vulnerabilities
+    - task: Bash@3
+      displayName: 'Check for High risk vulnerabilities'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Check for high-risk vulnerabilities
+          HIGH_VULNS=$(probely scans get ${SCAN_ID} --api-key $(PROBELY_API_KEY) -o JSON | jq -r '.[0].highs')
+          echo "HIGH risk vulnerabilities: ${HIGH_VULNS}"
+          if [[ "$HIGH_VULNS" -gt 0 ]]; then
+            echo "Scan has High risk vulnerabilities... aborting"
+            exit 1
+          else
+            echo "Scan doesn't have High risk vulnerabilities"
+          fi
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        SCAN_ID: $(SCAN_ID)

--- a/cicd-examples/azure-devops/azure-pipelines-remote-app-non-blocking-mode.yml
+++ b/cicd-examples/azure-devops/azure-pipelines-remote-app-non-blocking-mode.yml
@@ -1,0 +1,67 @@
+# Probely Security Scan - Remote App in Non-Blocking Mode
+# This pipeline triggers a security scan on a remote application (already running on your server)
+# The scan runs in non-blocking mode, allowing the pipeline to continue without waiting for results
+
+trigger:
+  branches:
+    include:
+    - main
+    - develop
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  # Configure these variables in Azure DevOps Pipeline Variables
+  # TARGET_ID: Your Probely target ID
+
+stages:
+- stage: SecurityScan
+  displayName: 'Security Scan'
+  jobs:
+  - job: ProbelyScan
+    displayName: 'Trigger Probely Security Scan'
+    steps:
+    
+    # Step 1: Install Probely CLI
+    - task: Bash@3
+      displayName: 'Install Probely CLI'
+      inputs:
+        targetType: 'inline'
+        script: |
+          # Install Probely CLI
+          pip install probely
+          # Test probely GET TARGETS
+          probely targets get --api-key $(PROBELY_API_KEY)
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+    
+    # Step 2: Start Security Scan (Non-blocking)
+    - task: Bash@3
+      displayName: 'Start Probely Scan'
+      inputs:
+        targetType: 'inline'
+        script: |
+          for i in {1..20}; do
+            echo "-----------------------------------"
+            SCAN_ID=$(probely targets start-scan $(TARGET_ID) -o IDS_ONLY --api-key $(PROBELY_API_KEY))
+            echo ${SCAN_ID}
+            if [ -f ${SCAN_ID} ]; then
+              echo "Scan didn't start... Retry start-scan"
+            else
+              echo "Scan started with SCAN ID: ${SCAN_ID}";
+              echo "##vso[task.setvariable variable=SCAN_ID]${SCAN_ID}"
+              break;
+            fi
+            sleep 5
+          done
+          if [ -f ${SCAN_ID} ]; then
+            echo "No Scan ID, aborting..."
+            exit 1
+          fi
+          
+          echo "Security scan initiated successfully. Scan ID: ${SCAN_ID}"
+          echo "The scan is running in the background. Check Probely dashboard for results."
+      env:
+        PROBELY_API_KEY: $(PROBELY_API_KEY)
+        TARGET_ID: $(TARGET_ID)


### PR DESCRIPTION
This PR adds Azure DevOps pipeline templates for Probely security scanning, following the same pattern as the existing GitHub Actions, GitLab, and BitBucket examples.

## Added Templates

- **azure-pipelines-ephemeral-app-blocking-mode.yml** - Scans containerized applications built within the CI/CD pipeline in blocking mode
- **azure-pipelines-remote-app-blocking-mode.yml** - Scans remote applications in blocking mode with vulnerability checks
- **azure-pipelines-remote-app-non-blocking-mode.yml** - Triggers scans on remote applications without waiting for completion

All templates:
- Use Probely CLI for security scanning
- Follow Azure DevOps best practices
- Include proper variable configuration for secrets and environment variables
- Support the same scanning scenarios as other CI/CD platforms